### PR TITLE
feat: konnector script commands simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ What's Cozy?
 
 ![Cozy Logo](https://cdn.rawgit.com/cozy/cozy-guidelines/master/templates/cozy_logo_small.svg)
 
-[Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
-
+[Cozy] is a platform that brings all your web services in the same private space. With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
 What's this new konnector?
 --------------------------
@@ -18,48 +17,30 @@ What's this new konnector?
 
 If you want to work on this konnector and submit code modifications, feel free to open pull-requests! See the [contributing guide][contribute] for more information about how to properly open pull-requests.
 
-### Run
+### Test the connector without an accessible cozy-stack
 
-If you have a running accessible cozy-stack you can test your modifications to the konnector without installing
-and/or updating the konnector in the cozy-stack :
+If you just want to test this connector without any cozy available.
 
 You first need an installed [nodejs] (LTS version is fine).
 
-Then just run (but you need to have proper COZY_CREDENTIALS, COZY_URL and COZY_FIELDS environment variables):
+We also suggest you tu use [yarn] instead of npm for node packages.
 
 ```sh
 npm install --global yarn
 ```
 
-Then run (but you have to have proper COZY_CREDENTIALS, COZY_URL and COZY_FIELDS environment variables):
+Then just run :
 
 ```sh
 yarn
-yarn start
+yarn standalone
 ```
 
-Where:
- - COZY_CREDENTIALS needs to be the result of ```cozy-stack instances token-cli <instance name> <scope>```
- - COZY_URL is the full http url to your cozy
- - COZY_FIELDS is something like :
-```javascript
-{
-  "data":{
-    "attributes":{
-      "arguments":{
-        "account":"cf31eaef5d899404a7e8c3737c1c2d1f",
-        "folder_to_save":"folderPath",
-        "slug":"mykonnector"
-      }
-    }
-  }
-}
-```
+The requests to the cozy-stack will be stubbed using the [./data/fixture.json] file as source of data
+and when cozy-client is asked to create or update data, the data will be output to the console.
+The bills (or any file) will be saved in the ./data directory.
 
-The "account" field is the id of the record with doctype "io.cozy.accounts" which will be used as
-parameters for your konnector.
-
-### Test
+### Run the connector linked to a cozy-stack
 
 If you do not want to have to install the konnector on a cozy v3 to test it, you can register the
 konnector as an OAuth application with the following commands :
@@ -77,23 +58,33 @@ After that, your konnector is running but should not work since you did not spec
 the target service. You can do this in a [./data/env_fields.json] (you have
 [./data/env_fields.json.template] available as a template)
 
-Now run ```yarn init:dev:account``` to create an account in the targeted cozy which will be used by
-the connector (the id of the account is saved in ./data/account.txt)
-
 Now run `yarn dev` one more time, it should be ok.
 
-### Hack
+### How does the cozy-stack run the connector ?
 
-If you do not want to need to have an accessible cozy-stack, just run :
+The cozy-stack runs the connector in a rkt container to be sure it does not affect the environment.
 
-```sh
-yarn
-yarn standalone
+The connector is run by calling npm start with the following envrionment variables :
+
+ - COZY_CREDENTIALS needs to be the result of ```cozy-stack instances token-cli <instance name> <scope>```
+ - COZY_URL is the full http or https url to your cozy
+ - COZY_FIELDS is something like :
+```javascript
+{
+  "data":{
+    "attributes":{
+      "arguments":{
+        "account":"cf31eaef5d899404a7e8c3737c1c2d1f",
+        "folder_to_save":"folderPath",
+        "slug":"mykonnector"
+      }
+    }
+  }
+}
 ```
 
-The requests to the cozy-stack will be stubbed using the [./data/fixture.json] file as source of data
-and when cozy-client is asked to create or update data, the data will be outputed to the console.
-The bills (or any file) will be saved in the ./data directory.
+The "account" field is the id of the record with doctype "io.cozy.accounts" which will be used as
+parameters for your konnector.
 
 ### Maintainer
 

--- a/data/env.js
+++ b/data/env.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+const path = require('path')
+const tokenPath = path.join(__dirname, 'token.json')
+
+module.exports = {
+  NODE_ENV: 'development',
+  COZY_CREDENTIALS: fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath, 'utf-8') : 'NO TOKEN',
+  COZY_URL: 'http://cozy.tools:8080'
+}

--- a/data/env_development.js
+++ b/data/env_development.js
@@ -1,6 +1,5 @@
-const fs = require('fs')
 const path = require('path')
-const tokenPath = path.join(__dirname, 'token.json')
+const fs = require('fs')
 
 // get the account id
 const accountIdPath = path.join(__dirname, 'account.txt')
@@ -9,12 +8,11 @@ if (fs.existsSync(accountIdPath)) {
   accountId = fs.readFileSync(accountIdPath, 'utf-8').trim()
 } else {
   console.log(`No account id file found. Please first run yarn init:dev:account`)
+  process.exit(0)
 }
 
-module.exports = {
-  COZY_CREDENTIALS: fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath) : 'NO TOKEN',
-  COZY_URL: 'http://cozy.tools:8080',
+module.exports = Object.assign(require('./env.js'), {
   NODE_ENV: 'development',
   COZY_FIELDS: `{"connector": "mykonnector", "account": "${accountId}", "folder_to_save": "folderPath"}`,
   DEBUG: '*'
-}
+})

--- a/data/env_standalone.js
+++ b/data/env_standalone.js
@@ -1,3 +1,4 @@
-module.exports = Object.assign(require('./env_development.js'), {
-  NODE_ENV: 'standalone'
+module.exports = Object.assign(require('./env.js'), {
+  NODE_ENV: 'standalone',
+  COZY_FIELDS: `{"connector": "mykonnector", "account": "noid", "folder_to_save": "folderPath"}`
 })

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "init:dev:account": "npm run predev && env-cmd ./data/env_development.js cozy-init-dev-account ./data/account.txt ./data/env_fields.json",
-    "predev": "env-cmd ./data/env_development.js cozy-authenticate manifest.konnector",
+    "oauth": "env-cmd ./data/env.js cozy-authenticate manifest.konnector",
+    "predev": "npm run oauth && env-cmd ./data/env.js cozy-init-dev-account ./data/account.txt ./data/env_fields.json",
     "dev": "env-cmd ./data/env_development.js npm start",
     "standalone": "env-cmd ./data/env_standalone.js npm start",
     "build": "webpack"
@@ -30,7 +30,7 @@
     "cz-conventional-changelog": "^2.0.0",
     "env-cmd": "^5.1.0",
     "request-debug": "^0.2.0",
-    "webpack": "^2.4.1"
+    "webpack": "^2.5.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This is a proposition of "simplification" of the npm script commands used in each connector.

With this, the konnector developer does not need to run the yarn init:dev:account anymore. It is run automatically when using the yarn dev command. If the ./data/env_fields.json does not exist, an error message is displayed.

This also needs an update of the cozy-konnector-libs package which is not published yet. Then a yarn link is needed with the master version of cozy-konnector-libs, at the moment.

The downside is that we need to update all the konnectors one more time to use this. But this goes in the sense of facilitating the life of konnectors developpeurs (I think)