### PR TITLE
fix: Push to the build branch with yarn deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "webpack",
     "lint": "standard --fix konnector.js",
     "deploy:travis": "git-directory-deploy --username <YOUR_GH_USERNAME> --email <YOUR_EMAIL> --directory build/ --repo=https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git",
-    "deploy": "git-directory-deploy --directory build/ --repo=https://github.com/<USERNAME_GH>/<SLUG_GH>.git"
+    "deploy": "git-directory-deploy --directory build/ --branch build --repo=https://github.com/<USERNAME_GH>/<SLUG_GH>.git"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^4.0.1",


### PR DESCRIPTION
@nicofrand has spotted this error: in the README, we say to run `yarn deploy` to have the konnector ready to be sued with an URL using the `build` branch, but git-directory-deploy pushes to `gh-pages` per default.