### PR TITLE
Add standardjs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "",
   "license": "AGPL-3.0",
   "dependencies": {
-    "cozy-konnector-libs": "^3.0.0"
+    "cozy-konnector-libs": "^3.0.0",
+    "standard": "^10.0.3"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
lint script used it without the package being dependent to it